### PR TITLE
Ada/37 downgrade type

### DIFF
--- a/dev-example/package-lock.json
+++ b/dev-example/package-lock.json
@@ -67,6 +67,7 @@
         "@actyx/sdk": "^0.5.7",
         "@types/events": "^3.0.0",
         "events": "^3.3.0",
+        "ts-node": "^10.9.1",
         "typed-emitter": "^2.1.0",
         "typescript": "^4.9.5"
       },
@@ -8100,6 +8101,7 @@
         "prettier": "^2.8.0",
         "rimraf": "^4.4.0",
         "ts-jest": "^29.0.5",
+        "ts-node": "^10.9.1",
         "typed-emitter": "^2.1.0",
         "typescript": "^4.9.5"
       }

--- a/dev-example/package-lock.json
+++ b/dev-example/package-lock.json
@@ -67,7 +67,8 @@
         "@actyx/sdk": "^0.5.7",
         "@types/events": "^3.0.0",
         "events": "^3.3.0",
-        "typed-emitter": "^2.1.0"
+        "typed-emitter": "^2.1.0",
+        "typescript": "^4.9.5"
       },
       "devDependencies": {
         "@jest/globals": "^29.4.2",
@@ -8099,7 +8100,8 @@
         "prettier": "^2.8.0",
         "rimraf": "^4.4.0",
         "ts-jest": "^29.0.5",
-        "typed-emitter": "^2.1.0"
+        "typed-emitter": "^2.1.0",
+        "typescript": "^4.9.5"
       }
     },
     "@actyx/machine-visual": {

--- a/machine-runner/jest.config.ts
+++ b/machine-runner/jest.config.ts
@@ -1,6 +1,7 @@
-/** @type {import('ts-jest').JestConfigWithTsJest} */
-module.exports = {
-  testEnvironment: 'node',
+import type { JestConfigWithTsJest } from 'ts-jest'
+
+const jestConfig: JestConfigWithTsJest = {
+  // [...]
   extensionsToTreatAsEsm: ['.ts'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
@@ -15,5 +16,5 @@ module.exports = {
       },
     ],
   },
-  roots: ['src'],
 }
+export default jestConfig

--- a/machine-runner/package-lock.json
+++ b/machine-runner/package-lock.json
@@ -12,7 +12,9 @@
         "@actyx/sdk": "^0.5.7",
         "@types/events": "^3.0.0",
         "events": "^3.3.0",
-        "typed-emitter": "^2.1.0"
+        "ts-node": "^10.9.1",
+        "typed-emitter": "^2.1.0",
+        "typescript": "^4.9.5"
       },
       "devDependencies": {
         "@jest/globals": "^29.4.2",
@@ -703,6 +705,26 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
@@ -1162,7 +1184,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
       "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1179,8 +1200,7 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.17",
@@ -1250,6 +1270,26 @@
       "dependencies": {
         "@sinonjs/commons": "^2.0.0"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.0",
@@ -1339,8 +1379,7 @@
     "node_modules/@types/node": {
       "version": "18.13.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
-      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
-      "dev": true
+      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg=="
     },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
@@ -1566,7 +1605,6 @@
       "version": "8.8.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
       "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1581,6 +1619,14 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -1662,6 +1708,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -2004,6 +2055,11 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+    },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
@@ -2071,6 +2127,14 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-sequences": {
@@ -3791,8 +3855,7 @@
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -4776,6 +4839,48 @@
         }
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -4839,11 +4944,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
-      "dev": true,
-      "peer": true,
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4886,6 +4989,11 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.0.1",
@@ -5049,6 +5157,14 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {
@@ -5583,6 +5699,25 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.9",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+          "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
+      }
+    },
     "@eslint/eslintrc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
@@ -5939,8 +6074,7 @@
     "@jridgewell/resolve-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "dev": true
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
     },
     "@jridgewell/set-array": {
       "version": "1.1.2",
@@ -5951,8 +6085,7 @@
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.17",
@@ -6013,6 +6146,26 @@
       "requires": {
         "@sinonjs/commons": "^2.0.0"
       }
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
     },
     "@types/babel__core": {
       "version": "7.20.0",
@@ -6102,8 +6255,7 @@
     "@types/node": {
       "version": "18.13.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
-      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
-      "dev": true
+      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg=="
     },
     "@types/prettier": {
       "version": "2.7.2",
@@ -6239,8 +6391,7 @@
     "acorn": {
       "version": "8.8.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
-      "dev": true
+      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA=="
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -6248,6 +6399,11 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
+    },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
     },
     "ajv": {
       "version": "6.12.6",
@@ -6302,6 +6458,11 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "argparse": {
       "version": "2.0.1",
@@ -6553,6 +6714,11 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+    },
     "cross-fetch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
@@ -6604,6 +6770,11 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "diff-sequences": {
       "version": "29.4.2",
@@ -7894,8 +8065,7 @@
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "makeerror": {
       "version": "1.0.12",
@@ -8583,6 +8753,26 @@
         "yargs-parser": "^21.0.1"
       }
     },
+    "ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      }
+    },
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -8628,11 +8818,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
-      "dev": true,
-      "peer": true
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
     },
     "update-browserslist-db": {
       "version": "1.0.10",
@@ -8652,6 +8840,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
     },
     "v8-to-istanbul": {
       "version": "9.0.1",
@@ -8774,6 +8967,11 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/machine-runner/package.json
+++ b/machine-runner/package.json
@@ -13,9 +13,9 @@
     "./lib/**/*"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --build tsconfig.build.json",
     "clean": "rimraf ./lib",
-    "test": "jest",
+    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
     "lint": "npx eslint src/**/*.ts",
     "prepublishOnly": "npm run clean && npm run build && npm run test && npm run lint"
   },
@@ -40,6 +40,8 @@
     "@actyx/sdk": "^0.5.7",
     "@types/events": "^3.0.0",
     "events": "^3.3.0",
-    "typed-emitter": "^2.1.0"
+    "ts-node": "^10.9.1",
+    "typed-emitter": "^2.1.0",
+    "typescript": "^4.9.5"
   }
 }

--- a/machine-runner/src/test-utils/mock-runner.ts
+++ b/machine-runner/src/test-utils/mock-runner.ts
@@ -51,7 +51,7 @@ type MockMachineRunnerTestUtils<
   feed: (
     ev: MachineEvent.Factory.ReduceToEvent<RegisteredEventsFactoriesTuple>[],
     props?: { caughtUp: boolean },
-  ) => ReturnType<Subscription.CallbackFnOf<RegisteredEventsFactoriesTuple>>
+  ) => Promise<void>
 
   /**
    * Asserts the state of the machine as being in the state  of a particular
@@ -123,7 +123,7 @@ export const createMockMachineRunner = <
   type Self = MockMachineRunner<SwarmProtocolName, MachineName, RegisteredEventsFactoriesTuple>
 
   const delayer = PromiseDelay.make()
-  const sub = Subscription.make<RegisteredEventsFactoriesTuple>()
+  const sub = Subscription.make()
   const persisted: MachineEvent.Any[] = []
 
   const feed: Self['test']['feed'] = (ev, props) => {
@@ -164,7 +164,7 @@ export const createMockMachineRunner = <
       persisted.push(...events)
       const pair = delayer.make()
       const retval = pair[0].then(() => {
-        feed(events, { caughtUp: true })
+        feed(events as any, { caughtUp: true })
         return events.map((_) => mockMeta())
       })
       return retval
@@ -259,14 +259,8 @@ export namespace PromiseDelay {
 }
 
 export namespace Subscription {
-  export type CallbackFnOf<
-    RegisteredEventsFactoriesTuple extends Readonly<MachineEvent.Factory.Any[]>,
-  > = Parameters<SubscribeFn<RegisteredEventsFactoriesTuple>>[0]
-
-  export const make = <
-    RegisteredEventsFactoriesTuple extends Readonly<MachineEvent.Factory.Any[]>,
-  >() => {
-    type Subscribe = SubscribeFn<RegisteredEventsFactoriesTuple>
+  export const make = <AllowedEvents extends MachineEvent.Any>() => {
+    type Subscribe = SubscribeFn<AllowedEvents>
     type Callback = Parameters<Subscribe>[0]
     type ErrorCallback = Parameters<Subscribe>[1]
 

--- a/machine-runner/src/utils/fn-utils.ts
+++ b/machine-runner/src/utils/fn-utils.ts
@@ -1,0 +1,3 @@
+export const NOP = <T extends unknown[]>(..._: T) => {
+  // do nothing
+}

--- a/machine-runner/src/utils/index.ts
+++ b/machine-runner/src/utils/index.ts
@@ -1,3 +1,0 @@
-export const NOP = (..._: unknown[]) => {
-  // do nothing
-}

--- a/machine-runner/tests/runner.test.ts
+++ b/machine-runner/tests/runner.test.ts
@@ -1,13 +1,18 @@
-import { EventsOrTimetravel, Metadata, MsgType, OnCompleteOrErr } from '@actyx/sdk'
+import { MsgType } from '@actyx/sdk'
 import { describe, expect, it } from '@jest/globals'
-import { createMachineRunnerInternal, State, StateOpaque, SubscribeFn } from './runner/runner.js'
-import { MachineEvent } from './design/event.js'
-import { StateFactory, StateMechanism } from './design/state.js'
-import { deepCopy } from './utils/object-utils.js'
-import { NOP } from './utils/index.js'
-import { Equal, Expect, NotAnyOrUnknown, NotEqual } from './utils/type-utils.js'
-import { MachineAnalysisResource, SwarmProtocol } from './design/protocol.js'
-import { PromiseDelay, Subscription, mockMeta } from './test-utils/mock-runner.js'
+import {
+  createMachineRunner,
+  createMachineRunnerInternal,
+  State,
+  StateOpaque,
+} from '../lib/runner/runner.js'
+import { MachineEvent } from '../lib/design/event.js'
+import { StateFactory, StateMechanism } from '../lib/design/state.js'
+import { deepCopy } from '../lib/utils/object-utils.js'
+import { NOP } from '../lib/utils/index.js'
+import { Equal, Expect, NotAnyOrUnknown, NotEqual } from '../lib/utils/type-utils.js'
+import { MachineAnalysisResource, SwarmProtocol } from '../lib/design/protocol.js'
+import { PromiseDelay, Subscription, mockMeta } from '../lib/test-utils/mock-runner.js'
 
 class Unreachable extends Error {
   constructor() {

--- a/machine-runner/tsconfig.build.json
+++ b/machine-runner/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["./src/**/*"]
+}

--- a/machine-runner/tsconfig.json
+++ b/machine-runner/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "include": ["src/**/*"],
   "compilerOptions": {
     "alwaysStrict": true,
     "declaration": true,

--- a/machine-visual/package-lock.json
+++ b/machine-visual/package-lock.json
@@ -64,6 +64,7 @@
         "@actyx/sdk": "^0.5.7",
         "@types/events": "^3.0.0",
         "events": "^3.3.0",
+        "ts-node": "^10.9.1",
         "typed-emitter": "^2.1.0",
         "typescript": "^4.9.5"
       },
@@ -2066,6 +2067,7 @@
         "prettier": "^2.8.0",
         "rimraf": "^4.4.0",
         "ts-jest": "^29.0.5",
+        "ts-node": "^10.9.1",
         "typed-emitter": "^2.1.0",
         "typescript": "^4.9.5"
       }

--- a/machine-visual/package-lock.json
+++ b/machine-visual/package-lock.json
@@ -64,7 +64,8 @@
         "@actyx/sdk": "^0.5.7",
         "@types/events": "^3.0.0",
         "events": "^3.3.0",
-        "typed-emitter": "^2.1.0"
+        "typed-emitter": "^2.1.0",
+        "typescript": "^4.9.5"
       },
       "devDependencies": {
         "@jest/globals": "^29.4.2",
@@ -2065,7 +2066,8 @@
         "prettier": "^2.8.0",
         "rimraf": "^4.4.0",
         "ts-jest": "^29.0.5",
-        "typed-emitter": "^2.1.0"
+        "typed-emitter": "^2.1.0",
+        "typescript": "^4.9.5"
       }
     },
     "@actyx/sdk": {


### PR DESCRIPTION
- Unit tests now targets files from `./lib` instead of `./src`
- Tests are moved under `tests` folder so that tests files are not packed into the resulting npm package