### PR TITLE
add state change tracking

### DIFF
--- a/dev-example/package-lock.json
+++ b/dev-example/package-lock.json
@@ -41,32 +41,37 @@
     },
     "../machine-check": {
       "name": "@actyx/machine-check",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dev": true,
       "license": "Apache-2.0",
       "devDependencies": {
-        "@actyx/machine-runner": "^0.3.1",
+        "@actyx/machine-runner": "^0.4.0",
         "@jest/globals": "^29.5.0",
+        "@types/glob": "^8.1.0",
         "@typescript-eslint/eslint-plugin": "^5.45.0",
         "@typescript-eslint/parser": "^5.45.0",
+        "cpy-cli": "^4.2.0",
         "eslint": "^8.28.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.2.1",
+        "glob": "^10.2.6",
         "jest": "^29.5.0",
         "prettier": "^2.8.0",
         "rimraf": "^4.4.1",
         "ts-jest": "^29.1.0",
+        "ts-node": "^10.9.1",
         "typescript": "^5.0.2"
       }
     },
     "../machine-runner": {
       "name": "@actyx/machine-runner",
-      "version": "0.4.2",
+      "version": "0.4.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@actyx/sdk": "^0.5.7",
         "@types/events": "^3.0.0",
         "events": "^3.3.0",
+        "fast-equals": "^5.0.1",
         "ts-node": "^10.9.1",
         "typed-emitter": "^2.1.0",
         "typescript": "^4.9.5"
@@ -8074,17 +8079,21 @@
     "@actyx/machine-check": {
       "version": "file:../machine-check",
       "requires": {
-        "@actyx/machine-runner": "^0.3.1",
+        "@actyx/machine-runner": "^0.4.0",
         "@jest/globals": "^29.5.0",
+        "@types/glob": "^8.1.0",
         "@typescript-eslint/eslint-plugin": "^5.45.0",
         "@typescript-eslint/parser": "^5.45.0",
+        "cpy-cli": "^4.2.0",
         "eslint": "^8.28.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.2.1",
+        "glob": "^10.2.6",
         "jest": "^29.5.0",
         "prettier": "^2.8.0",
         "rimraf": "^4.4.1",
         "ts-jest": "^29.1.0",
+        "ts-node": "^10.9.1",
         "typescript": "^5.0.2"
       }
     },
@@ -8102,6 +8111,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.2.1",
         "events": "^3.3.0",
+        "fast-equals": "^5.0.1",
         "glob": "^10.2.6",
         "jest": "^29.4.2",
         "prettier": "^2.8.0",

--- a/machine-runner/README.md
+++ b/machine-runner/README.md
@@ -214,6 +214,13 @@ If the workflow still is in the `Auction` state, we compute the best robot bid (
 The third feature becomes relevant once the auction has ended: we check if our robot is indeed the winner and record that in a variable `IamWinner`, i.e. in the current application in-memory state.
 Then we can use this information in all following states as well.
 
+### Change detection on for-await loop
+
+When using for-await loop with the machine runner, the loop iterates only if the following criteria matches:
+
+- A 'caughtUp' event is emitted; It happens when the machine runner receives the latest event published in Actyx;
+- An event between the current `caughtUp` and the previous one triggers a change to the machine's state; The state change is determined by comparing the name and payload between the state before and after the `caughtUp` event. The comparison uses the `deepEqual` function provided by the [fast-equal package](https://www.npmjs.com/package/fast-equals).
+
 ### The consequences of Eventual Consensus
 
 The design goal of Actyx and the machine runner is to provide uncompromising resilience and availability, meaning that if a device is capable of computation it shall be able to make progress, independent of the network.

--- a/machine-runner/README.md
+++ b/machine-runner/README.md
@@ -216,7 +216,7 @@ Then we can use this information in all following states as well.
 
 ### Change detection on for-await loop
 
-When using for-await loop with the machine runner, the loop iterates only if the following criteria matches:
+When using a for-await loop with the machine runner, the loop iterates only if all of the following criteria are met:
 
 - A 'caughtUp' event is emitted; It happens when the machine runner receives the latest event published in Actyx;
 - An event between the current `caughtUp` and the previous one triggers a change to the machine's state; The state change is determined by comparing the name and payload between the state before and after the `caughtUp` event. The comparison uses the `deepEqual` function provided by the [fast-equal package](https://www.npmjs.com/package/fast-equals).

--- a/machine-runner/package-lock.json
+++ b/machine-runner/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@actyx/machine-runner",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@actyx/machine-runner",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@actyx/sdk": "^0.5.7",
         "@types/events": "^3.0.0",
         "events": "^3.3.0",
+        "fast-equals": "^5.0.1",
         "ts-node": "^10.9.1",
         "typed-emitter": "^2.1.0",
         "typescript": "^4.9.5"
@@ -2710,6 +2711,14 @@
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
+    },
+    "node_modules/fast-equals": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.0.1.tgz",
+      "integrity": "sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.2.12",
@@ -7572,6 +7581,11 @@
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
+    },
+    "fast-equals": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.0.1.tgz",
+      "integrity": "sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ=="
     },
     "fast-glob": {
       "version": "3.2.12",

--- a/machine-runner/package.json
+++ b/machine-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actyx/machine-runner",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "asymmetric replicated state machines: runtime support",
   "type": "module",
   "types": "./lib/esm/index.d.ts",
@@ -64,6 +64,7 @@
     "@actyx/sdk": "^0.5.7",
     "@types/events": "^3.0.0",
     "events": "^3.3.0",
+    "fast-equals": "^5.0.1",
     "ts-node": "^10.9.1",
     "typed-emitter": "^2.1.0",
     "typescript": "^4.9.5"

--- a/machine-runner/src/runner/runner-internals.ts
+++ b/machine-runner/src/runner/runner-internals.ts
@@ -48,6 +48,15 @@ export type RunnerInternals<
     Commands
   >
 
+  previouslyEmittedToNext: null | StateAndFactory<
+    SwarmProtocolName,
+    MachineName,
+    MachineEventFactories,
+    StateName,
+    StatePayload,
+    Commands
+  >
+
   // TODO: document how it behaves
   commandLock: null | symbol
 }
@@ -106,6 +115,7 @@ export namespace RunnerInternals {
       caughtUp: false,
       caughtUpFirstTime: false,
       commandLock: null,
+      previouslyEmittedToNext: null,
     }
 
     return internals

--- a/machine-runner/src/runner/runner-utils.ts
+++ b/machine-runner/src/runner/runner-utils.ts
@@ -42,6 +42,7 @@ export type MachineEmitterEventMap<
     nextState: unknown
   }) => unknown
   change: (_: StateOpaque<SwarmProtocolName, MachineName, string, StateUnion>) => unknown
+  next: (_: StateOpaque<SwarmProtocolName, MachineName, string, StateUnion>) => unknown
   destroyed: (_: void) => unknown
   log: (_: string) => unknown
 }

--- a/machine-runner/src/runner/runner.ts
+++ b/machine-runner/src/runner/runner.ts
@@ -395,7 +395,11 @@ export const createMachineRunnerInternal = <
               internals.caughtUpFirstTime = true
               emitter.emit('log', 'Caught up')
 
-              const stateOpaqueToBeEmitted = ImplStateOpaque.make(internals, internals.current)
+              const stateOpaqueToBeEmitted = ImplStateOpaque.make<
+                SwarmProtocolName,
+                MachineName,
+                StateUnion
+              >(internals, internals.current)
               emitter.emit('change', stateOpaqueToBeEmitted)
 
               if (

--- a/machine-runner/src/utils/object-utils.ts
+++ b/machine-runner/src/utils/object-utils.ts
@@ -4,18 +4,25 @@
 export const jsonDeepCopy = <T>(item: T): T => JSON.parse(JSON.stringify(item))
 
 export function deepCopy<T>(source: T): T {
-  return Array.isArray(source)
-    ? source.map(deepCopy)
-    : source instanceof Date
-    ? new Date(source.getTime())
-    : typeof source === 'object' && source
-    ? Object.entries(Object.getOwnPropertyDescriptors(source)).reduce((o, [prop, descr]) => {
-        if (typeof descr.get === 'function') {
-          throw new Error('cannot deepCopy objects with accessors')
-        }
-        descr.value = deepCopy(descr.value)
-        Object.defineProperty(o, prop, descr)
-        return o
-      }, Object.create(Object.getPrototypeOf(source)))
-    : source
+  if (source instanceof Map)
+    return new Map(Array.from(source.entries()).map(([key, val]) => [key, deepCopy(val)])) as T
+
+  if (source instanceof Set) return new Set(Array.from(source).map(deepCopy)) as T
+
+  if (source instanceof Date) return new Date(source) as T
+
+  if (Array.isArray(source)) return source.map(deepCopy) as T
+
+  if (typeof source === 'object' && source) {
+    return Object.entries(Object.getOwnPropertyDescriptors(source)).reduce((o, [prop, descr]) => {
+      if (typeof descr.get === 'function') {
+        throw new Error('cannot deepCopy objects with accessors')
+      }
+      descr.value = deepCopy(descr.value)
+      Object.defineProperty(o, prop, descr)
+      return o
+    }, Object.create(Object.getPrototypeOf(source)))
+  }
+
+  return source
 }

--- a/machine-runner/tests/esm/deepCopy.test.ts
+++ b/machine-runner/tests/esm/deepCopy.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from '@jest/globals'
+import { deepCopy } from '../../lib/esm/utils/object-utils.js'
+
+describe('deepCopy', () => {
+  it('should copies primitives', () => {
+    expect(true).toBe(true)
+    expect(false).toBe(false)
+    expect(null).toBe(null)
+    expect(undefined).toBe(undefined)
+    expect(deepCopy(1)).toBe(1)
+    expect(deepCopy(BigInt('1'))).toBe(BigInt('1'))
+    expect(deepCopy('helloworld')).toBe('helloworld')
+    const SOME_SYMBOL = Symbol()
+    expect(SOME_SYMBOL).toBe(SOME_SYMBOL)
+  })
+
+  it('copies arrays and keyed collections', () => {
+    expect(deepCopy([1, 2, 3])).toEqual([1, 2, 3])
+    expect(deepCopy([1, { a: 'b' }, [1, 2, 3]])).toEqual([1, { a: 'b' }, [1, 2, 3]])
+    expect(deepCopy([null, true, 5, 'world'])).toEqual([null, true, 5, 'world'])
+    ;(() => {
+      const someObject = { b: 'asdfasdf' }
+      const setContent = [1, 2, 3, someObject, 'asdf']
+      const setA = new Set(setContent)
+      const setB = deepCopy(setA)
+      expect(setA).not.toBe(setB)
+      expect(setB.has(1)).toBe(true)
+      expect(setB.has(2)).toBe(true)
+      expect(setB.has(3)).toBe(true)
+      expect(setB.has(someObject)).toBe(false) // not ===
+      expect(setB.has('asdf')).toBe(true)
+    })()
+    ;(() => {
+      const someObject = { b: 'asdfasdf' }
+      const mapA = new Map<any, any>([
+        [1, '1'],
+        ['1', 'someString'],
+        ['2', someObject],
+        ['3', [1, 2, 3, 4]],
+      ])
+      const mapB = deepCopy(mapA)
+      expect(mapA).not.toBe(mapB)
+      expect(mapA.size).toBe(mapB.size)
+      expect(mapA.get(1)).toBe(mapB.get(1))
+      expect(mapA.get('1')).toBe(mapB.get('1'))
+      expect(mapA.get('2')).not.toBe(mapB.get('2'))
+      expect(mapA.get('2')).toEqual(mapB.get('2'))
+      expect(mapA.get('3')).not.toBe(mapB.get('3'))
+      expect(mapA.get('3')).toEqual(mapB.get('3'))
+    })()
+  })
+
+  it('should copy objects', () => {
+    expect({ a: '5' }).not.toEqual({ a: 5 }) // just double-checking jest here
+    expect(deepCopy({ 0: true, a: '5' })).toEqual({ '0': true, a: '5' }) // JS only has string keys
+  })
+
+  it('should copy functions', () => {
+    let v = 42
+    const f = () => v
+    const c = deepCopy(f)
+    expect(c()).toBe(42)
+    v = 5
+    expect(c()).toBe(5)
+    const x = deepCopy({ f })
+    expect(x.f()).toBe(5)
+    v = 6
+    expect(x.f()).toBe(6)
+  })
+})

--- a/machine-visual/package-lock.json
+++ b/machine-visual/package-lock.json
@@ -58,12 +58,13 @@
     },
     "../machine-runner": {
       "name": "@actyx/machine-runner",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@actyx/sdk": "^0.5.7",
         "@types/events": "^3.0.0",
         "events": "^3.3.0",
+        "fast-equals": "^5.0.1",
         "ts-node": "^10.9.1",
         "typed-emitter": "^2.1.0",
         "typescript": "^4.9.5"
@@ -2068,6 +2069,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.2.1",
         "events": "^3.3.0",
+        "fast-equals": "^5.0.1",
         "glob": "^10.2.6",
         "jest": "^29.4.2",
         "prettier": "^2.8.0",


### PR DESCRIPTION
This guarantees `.next()` (and consequently for await) will resolve with `done: false, value: not null` ONLY when:
- Caught up for the first time
- Caught up after a state change
- Caught up after a time travel
- Command publishing fails